### PR TITLE
Fix missing semicolon in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Each request will return a batch of delivery reports - only once.
     var smsDeliveryResult = sendSmsApi.GetOutboundSmsMessageDeliveryReports(bulkId, messageId, numberOfReportsLimit);
     foreach (var smsReport in smsDeliveryResult.Results)
     {
-        Console.WriteLine($"{smsReport.MessageId} - {smsReport.Status.Name}")
+        Console.WriteLine($"{smsReport.MessageId} - {smsReport.Status.Name}");
     }
 ```
 


### PR DESCRIPTION
The missing semicolon causes a compiletime error if the code is copied as is. This could be confusing for new developers.