### PR TITLE
Fix memory leak

### DIFF
--- a/src/Infobip.Api.Client/Client/ApiClient.cs
+++ b/src/Infobip.Api.Client/Client/ApiClient.cs
@@ -89,9 +89,9 @@ namespace Infobip.Api.Client
             return JsonConvert.SerializeObject(obj, _serializerSettings);
         }
 
-        public T Deserialize<T>(HttpResponseMessage response)
+        public async Task<T> DeserializeAsync<T>(HttpResponseMessage response)
         {
-            var result = (T)Deserialize(response, typeof(T));
+            var result = (T) await DeserializeAsync(response, typeof(T)).ConfigureAwait(false);
             return result;
         }
 
@@ -101,17 +101,17 @@ namespace Infobip.Api.Client
         /// <param name="response">The HTTP response.</param>
         /// <param name="type">Object type.</param>
         /// <returns>Object representation of the JSON string.</returns>
-        internal object Deserialize(HttpResponseMessage response, Type type)
+        internal async Task<object> DeserializeAsync(HttpResponseMessage response, Type type)
         {
             IList<string> headers = response.Headers.Select(x => x.Key + "=" + x.Value).ToList();
 
             if (type == typeof(byte[])) // return byte array
-                return response.Content.ReadAsByteArrayAsync().Result;
+                return await response.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
 
             // TODO: ? if (type.IsAssignableFrom(typeof(Stream)))
             if (type == typeof(Stream))
             {
-                var bytes = response.Content.ReadAsByteArrayAsync().Result;
+                var bytes = await response.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
                 if (headers != null)
                 {
                     var filePath = string.IsNullOrEmpty(_configuration.TempFolderPath)
@@ -137,16 +137,16 @@ namespace Infobip.Api.Client
             }
 
             if (type.Name.StartsWith("System.Nullable`1[[System.DateTime")) // return a datetime object
-                return DateTime.Parse(response.Content.ReadAsStringAsync().Result, null,
+                return DateTime.Parse(await response.Content.ReadAsStringAsync().ConfigureAwait(false), null,
                     System.Globalization.DateTimeStyles.RoundtripKind);
 
             if (type == typeof(string) || type.Name.StartsWith("System.Nullable")) // return primitive type
-                return Convert.ChangeType(response.Content.ReadAsStringAsync().Result, type);
+                return Convert.ChangeType(await response.Content.ReadAsStringAsync().ConfigureAwait(false), type);
 
             // at this point, it must be a model (json)
             try
             {
-                return JsonConvert.DeserializeObject(response.Content.ReadAsStringAsync().Result, type,
+                return JsonConvert.DeserializeObject(await response.Content.ReadAsStringAsync().ConfigureAwait(false), type,
                     _serializerSettings);
             }
             catch (Exception e)
@@ -157,7 +157,7 @@ namespace Infobip.Api.Client
     }
 
     /// <summary>
-    ///     Provides a default implementation of an Api client (both synchronous and asynchronous implementatios),
+    ///     Provides a default implementation of an Api client (both synchronous and asynchronous implementations),
     ///     encapsulating general REST accessor use cases.
     /// </summary>
     /// <remarks>
@@ -393,12 +393,12 @@ namespace Infobip.Api.Client
             return request;
         }
 
-        private ApiResponse<T> ToApiResponse<T>(HttpResponseMessage response, object responseData, Uri uri)
+        private async Task<ApiResponse<T>> ToApiResponseAsync<T>(HttpResponseMessage response, object responseData, Uri uri)
         {
             var result = (T)responseData;
             string rawContent = response.Content.ToString();
             if (!response.IsSuccessStatusCode)
-                rawContent = response.Content.ReadAsStringAsync().Result;
+                rawContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 
             var transformed =
                 new ApiResponse<T>(response.StatusCode, new Multimap<string, string>(), result, rawContent)
@@ -432,7 +432,7 @@ namespace Infobip.Api.Client
 
         private ApiResponse<T> Exec<T>(HttpRequestMessage req, IReadableConfiguration configuration)
         {
-            return ExecAsync<T>(req, configuration).Result;
+            return ExecAsync<T>(req, configuration).GetAwaiter().GetResult();
         }
 
         private async Task<ApiResponse<T>> ExecAsync<T>(HttpRequestMessage req,
@@ -501,15 +501,15 @@ namespace Infobip.Api.Client
                     response = await _httpClient.SendAsync(req, finalToken).ConfigureAwait(false);
                 }
 
-                object responseData = deserializer.Deserialize<T>(response);
+                object responseData = await deserializer.DeserializeAsync<T>(response).ConfigureAwait(false);
 
                 // if the response type is oneOf/anyOf, call FromJSON to deserialize the data
                 if (typeof(AbstractOpenAPISchema).IsAssignableFrom(typeof(T)))
                     responseData = (T)typeof(T).GetMethod("FromJson")?.Invoke(null, new object[] { response.Content });
                 else if (typeof(T).Name == "Stream") // for binary response
-                    responseData = (T)(object)await response.Content.ReadAsStreamAsync();
+                    responseData = (T)(object)await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
 
-                var result = ToApiResponse<T>(response, responseData, req.RequestUri);
+                var result = await ToApiResponseAsync<T>(response, responseData, req.RequestUri).ConfigureAwait(false);
 
                 return result;
             }

--- a/src/Infobip.Api.Client/Client/ApiClient.cs
+++ b/src/Infobip.Api.Client/Client/ApiClient.cs
@@ -441,73 +441,82 @@ namespace Infobip.Api.Client
         {
             var deserializer = new CustomJsonCodec(SerializerSettings, configuration);
 
+            CancellationTokenSource timeoutCancellationTokenSource = null;
             var finalToken = cancellationToken;
 
-            if (configuration.Timeout > 0)
+            try
             {
-                var tokenSource = new CancellationTokenSource(configuration.Timeout);
-                finalToken = CancellationTokenSource.CreateLinkedTokenSource(finalToken, tokenSource.Token).Token;
-            }
+                if (configuration.Timeout > 0)
+                {
+                    timeoutCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                    timeoutCancellationTokenSource.CancelAfter(configuration.Timeout);
+                    finalToken = timeoutCancellationTokenSource.Token;
+                }
 
-            if (configuration.Proxy != null)
+                if (configuration.Proxy != null)
+                {
+                    if (_httpClientHandler == null)
+                        throw new InvalidOperationException(
+                            "Configuration `Proxy` not supported when the client is explicitly created without an HttpClientHandler, use the proper constructor.");
+                    _httpClientHandler.Proxy = configuration.Proxy;
+                }
+
+                if (configuration.ClientCertificates != null)
+                {
+                    if (_httpClientHandler == null)
+                        throw new InvalidOperationException(
+                            "Configuration `ClientCertificates` not supported when the client is explicitly created without an HttpClientHandler, use the proper constructor.");
+                    _httpClientHandler.ClientCertificates.AddRange(configuration.ClientCertificates);
+                }
+
+                var cookieContainer = req.Properties.ContainsKey("CookieContainer")
+                    ? req.Properties["CookieContainer"] as List<Cookie>
+                    : null;
+
+                if (cookieContainer != null)
+                {
+                    if (_httpClientHandler == null)
+                        throw new InvalidOperationException(
+                            "Request property `CookieContainer` not supported when the client is explicitly created without an HttpClientHandler, use the proper constructor.");
+                    foreach (var cookie in cookieContainer) _httpClientHandler.CookieContainer.Add(cookie);
+                }
+
+                HttpResponseMessage response;
+                if (RetryConfiguration.AsyncRetryPolicy != null)
+                {
+                    var policy = RetryConfiguration.AsyncRetryPolicy;
+                    var policyResult = await policy
+                        .ExecuteAndCaptureAsync(() => _httpClient.SendAsync(req, finalToken))
+                        .ConfigureAwait(false);
+                    response = policyResult.Outcome == OutcomeType.Successful
+                        ? policyResult.Result
+                        : new HttpResponseMessage
+                        {
+                            ReasonPhrase = policyResult.FinalException.ToString(),
+                            RequestMessage = req
+                        };
+                }
+                else
+                {
+                    response = await _httpClient.SendAsync(req, finalToken).ConfigureAwait(false);
+                }
+
+                object responseData = deserializer.Deserialize<T>(response);
+
+                // if the response type is oneOf/anyOf, call FromJSON to deserialize the data
+                if (typeof(AbstractOpenAPISchema).IsAssignableFrom(typeof(T)))
+                    responseData = (T)typeof(T).GetMethod("FromJson")?.Invoke(null, new object[] { response.Content });
+                else if (typeof(T).Name == "Stream") // for binary response
+                    responseData = (T)(object)await response.Content.ReadAsStreamAsync();
+
+                var result = ToApiResponse<T>(response, responseData, req.RequestUri);
+
+                return result;
+            }
+            finally
             {
-                if (_httpClientHandler == null)
-                    throw new InvalidOperationException(
-                        "Configuration `Proxy` not supported when the client is explicitly created without an HttpClientHandler, use the proper constructor.");
-                _httpClientHandler.Proxy = configuration.Proxy;
+                timeoutCancellationTokenSource?.Dispose();
             }
-
-            if (configuration.ClientCertificates != null)
-            {
-                if (_httpClientHandler == null)
-                    throw new InvalidOperationException(
-                        "Configuration `ClientCertificates` not supported when the client is explicitly created without an HttpClientHandler, use the proper constructor.");
-                _httpClientHandler.ClientCertificates.AddRange(configuration.ClientCertificates);
-            }
-
-            var cookieContainer = req.Properties.ContainsKey("CookieContainer")
-                ? req.Properties["CookieContainer"] as List<Cookie>
-                : null;
-
-            if (cookieContainer != null)
-            {
-                if (_httpClientHandler == null)
-                    throw new InvalidOperationException(
-                        "Request property `CookieContainer` not supported when the client is explicitly created without an HttpClientHandler, use the proper constructor.");
-                foreach (var cookie in cookieContainer) _httpClientHandler.CookieContainer.Add(cookie);
-            }
-
-            HttpResponseMessage response;
-            if (RetryConfiguration.AsyncRetryPolicy != null)
-            {
-                var policy = RetryConfiguration.AsyncRetryPolicy;
-                var policyResult = await policy
-                    .ExecuteAndCaptureAsync(() => _httpClient.SendAsync(req, cancellationToken))
-                    .ConfigureAwait(false);
-                response = policyResult.Outcome == OutcomeType.Successful
-                    ? policyResult.Result
-                    : new HttpResponseMessage
-                    {
-                        ReasonPhrase = policyResult.FinalException.ToString(),
-                        RequestMessage = req
-                    };
-            }
-            else
-            {
-                response = await _httpClient.SendAsync(req, cancellationToken).ConfigureAwait(false);
-            }
-
-            object responseData = deserializer.Deserialize<T>(response);
-
-            // if the response type is oneOf/anyOf, call FromJSON to deserialize the data
-            if (typeof(AbstractOpenAPISchema).IsAssignableFrom(typeof(T)))
-                responseData = (T)typeof(T).GetMethod("FromJson")?.Invoke(null, new object[] { response.Content });
-            else if (typeof(T).Name == "Stream") // for binary response
-                responseData = (T)(object)await response.Content.ReadAsStreamAsync();
-
-            var result = ToApiResponse<T>(response, responseData, req.RequestUri);
-
-            return result;
         }
 
         #region IAsynchronousClient

--- a/src/Infobip.Api.Client/Infobip.Api.Client.csproj
+++ b/src/Infobip.Api.Client/Infobip.Api.Client.csproj
@@ -9,7 +9,7 @@
     <Authors>Infobip</Authors>
     <Company>Infobip</Company>
     <AssemblyTitle>Infobip.Api.Client</AssemblyTitle>
-    <Description>C# library for consuming Infobip&#39;s API</Description>
+    <Description>C# library for consuming Infobip's API</Description>
     <Copyright>Copyright @ Infobip ltd. All rights reserved.</Copyright>
     <RootNamespace>Infobip.Api.Client</RootNamespace>
     <Version>2.1.0</Version>
@@ -25,7 +25,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
     <PackageReference Include="Polly" Version="7.2.1" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
   </ItemGroup>

--- a/src/Infobip.Api.Client/Infobip.Api.Client.csproj
+++ b/src/Infobip.Api.Client/Infobip.Api.Client.csproj
@@ -12,9 +12,9 @@
     <Description>C# library for consuming Infobip's API</Description>
     <Copyright>Copyright @ Infobip ltd. All rights reserved.</Copyright>
     <RootNamespace>Infobip.Api.Client</RootNamespace>
-    <Version>2.1.0</Version>
-    <FileVersion>2.1.0</FileVersion>
-    <AssemblyVersion>2.1.0</AssemblyVersion>
+    <Version>2.2.0</Version>
+    <FileVersion>2.2.0</FileVersion>
+    <AssemblyVersion>2.2.0</AssemblyVersion>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\Infobip.Api.Client.xml</DocumentationFile>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryUrl>https://github.com/infobip/infobip-api-csharp-client.git</RepositoryUrl>

--- a/src/Infobip.Api.Client/Infobip.Api.Client.csproj
+++ b/src/Infobip.Api.Client/Infobip.Api.Client.csproj
@@ -22,6 +22,8 @@
     <PackageReleaseNotes>Support for Infobip Email API included in library</PackageReleaseNotes>
     <PackageTags>Infobip API SMS TFA 2FA Email dotnet .NET Core C# CSharp client</PackageTags>
     <PackageIcon>icon.png</PackageIcon>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
If cancellation token used for many request (for example, long living queue consumer), memory will leak because [LinkedCancellationTokenSource is not disposed](https://github.com/infobip/infobip-api-csharp-client/blob/0f19c1e4a22151799a02b06da9c0c2b42d16cc48/src/Infobip.Api.Client/Client/ApiClient.cs).

Code to reproduce:

```
using Infobip.Api.Client.Api;
using Infobip.Api.Client;
using Infobip.Api.Client.Model;

var configuration = new Configuration()
{
    BasePath = "https://api.infobip.com",
    UserAgent = "Test",
    Username = "",
    Password = ""
};

var client = new SendSmsApi(configuration);

var smsRequest = new SmsAdvancedTextualRequest
{
    Messages = new List<SmsTextualMessage>
    {
        new()
        {
            From = "From",
            Destinations = new List<SmsDestination>
            {
                new(to: "79112223344")
            },
            Text = "Text"
        }
    }
};

var cts = new CancellationTokenSource();

for (int i = 0; ; i++)
{
    try
    {
        var smsResponse = await client.SendSmsMessageAsync(smsRequest, cts.Token);
    }
    catch
    {
    }
}
```

Before changes after ~5 minutes of work:
![Screenshot 2022-12-09 165914](https://user-images.githubusercontent.com/238041/206725217-ef075cd3-1870-41a9-83f2-c93a3701f325.png)

After:
![after](https://user-images.githubusercontent.com/238041/206725235-fb642b4c-de5f-4df1-bc6b-46c201493401.png)
