### PR TITLE
Add `IDisposable` to `IApiAccessor`

### DIFF
--- a/src/Infobip.Api.Client/Client/IApiAccessor.cs
+++ b/src/Infobip.Api.Client/Client/IApiAccessor.cs
@@ -9,12 +9,14 @@
  */
 
 
+using System;
+
 namespace Infobip.Api.Client
 {
     /// <summary>
     ///     Represents configuration aspects required to interact with the API endpoints.
     /// </summary>
-    public interface IApiAccessor
+    public interface IApiAccessor : IDisposable
     {
         /// <summary>
         ///     Gets or sets the configuration object


### PR DESCRIPTION
For some reason `IDisposable` is missing for all `IApiAccessor` implementations.

This PR makes it possible to use `using`:
```
using var smsApi = new SmsApi(...);
```